### PR TITLE
Raise escape-timeout from 0 to 1 to avoid catching Bash color codes w…

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -69,7 +69,7 @@ main() {
 
 	# address vim mode switching delay (http://superuser.com/a/252717/65504)
 	if server_option_value_not_changed "escape-time" "500"; then
-		tmux set-option -s escape-time 0
+		tmux set-option -s escape-time 1
 	fi
 
 	# increase scrollback buffer size


### PR DESCRIPTION
…hen loading several components in the .bashrc file on Windows Subsystem for Linux 2.