### PR TITLE
Use tmux's `default-shell` opt to get preffered SHELL for `default-co…

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -37,6 +37,11 @@ option_value_not_changed() {
 	[ "$option_value" == "$default_value" ]
 }
 
+get_server_option_value() {
+	local option="$1"
+	tmux show-options -gv "$option"
+}
+
 server_option_value_not_changed() {
 	local option="$1"
 	local default_value="$2"
@@ -100,7 +105,7 @@ main() {
 
 	# required (only) on OS X
 	if is_osx && command_exists "reattach-to-user-namespace" && option_value_not_changed "default-command" ""; then
-		tmux set-option -g default-command "reattach-to-user-namespace -l $SHELL"
+		tmux set-option -g default-command "reattach-to-user-namespace -l $(get_server_option_value 'default-shell')"
 	fi
 
 	# upgrade $TERM, tmux 1.9


### PR DESCRIPTION
…mmand` in OSX

tmux-sensible modified `default-command` for OSX to use `reattach-to-user-namespace` when creating shell with user preffered shell type from `SHELL` environment variable for circumventing OSX's process namespace segregation.
Prior to tmux 3.5 this `SHELL` environment variable was not modified by Tmux when running a shell command with tmux's default `sh` shell, so this worked fine.
Now from tmux 3.5 `SHELL` environment variable is set to `sh`, this causes tmux to load `sh` shell when executing default-command instead of user preffered shell when using tmux-sensible plugin.